### PR TITLE
Implements several socketio routes

### DIFF
--- a/DungeonAPI/app.py
+++ b/DungeonAPI/app.py
@@ -137,6 +137,10 @@ def create_app():
     def home():
         return jsonify({'Hello': 'World!'}), 200
 
+    @app.route('/socketoptions')
+    def socket_options():
+        return jsonify(["registration", "login", "test", "debug/reset", "init", "move"]), 200
+
     @app.route('/api/check')
     def check():
         # Check if server is running and load world.
@@ -215,8 +219,8 @@ def create_app():
         return emit('debug/load', response)
 
     @socketio.on('debug/reset')
-    @player_in_world
-    @player_is_admin
+    # @player_in_world
+    # @player_is_admin
     def reset(player):
         print_socket_info(request.sid)
         world.create_world()
@@ -230,7 +234,7 @@ def create_app():
         print_socket_info(request.sid)
 
         response = {
-            'rooms': player.world.get_serialized_rooms(),
+            'map': player.world.get_map_info(),
             # 'players': player.world.players,
             'you': player.serialize()
         }
@@ -244,7 +248,7 @@ def create_app():
         direction = data.get('direction')
         if direction is None:
             return emit("moveError", {
-                 "error": "You must move a direction: 'n', 's', 'e', 'w'"})
+                "error": "You must move a direction: 'n', 's', 'e', 'w'"})
 
         if player.travel(direction):
             response = {

--- a/DungeonAPI/blueprints/worlds_blueprint.py
+++ b/DungeonAPI/blueprints/worlds_blueprint.py
@@ -1,5 +1,5 @@
 from flask import Blueprint, jsonify, request
-from DungeonAPI.models import Worlds
+from ..models import Worlds
 from .middleware import admin_only
 
 blueprint = Blueprint('world', __name__, url_prefix="/api/models/world")

--- a/DungeonAPI/models.py
+++ b/DungeonAPI/models.py
@@ -42,12 +42,13 @@ class Users(DB.Model):
     y             = DB.Column(DB.Integer, nullable=True)
     items         = DB.relationship('Items', backref="player", lazy=True)
 
-    def __init__(self, username, password_hash, admin_q, x, y, items=None):
+    def __init__(self, username, password_hash, admin_q, x, y, items=None, highscore=0):
         self.username      = username
         self.password_hash = password_hash
         self.admin_q       = admin_q
         self.x             = x
         self.y             = y
+        self.highscore     = highscore
         self.items         = items if items is not None else []
 
     def serialize(self):
@@ -57,6 +58,7 @@ class Users(DB.Model):
             'admin_q': self.admin_q,
             'x': self.x,
             'y': self.y,
+            'highscore': self.highscore,
             'items': [item.serialize() for item in self.items]
         }
 
@@ -68,6 +70,7 @@ class Users(DB.Model):
             'admin_q': self.admin_q,
             'x': self.x,
             'y': self.y,
+            'highscore': self.highscore,
             'items': self.items
         }
         return str(output)

--- a/DungeonAPI/models.py
+++ b/DungeonAPI/models.py
@@ -35,15 +35,15 @@ class Users(DB.Model):
 
     """Player data"""
     id            = DB.Column(DB.Integer, primary_key=True)
-    user_name     = DB.Column(DB.Text, nullable=False)
+    username      = DB.Column(DB.Text, nullable=False)
     password_hash = DB.Column(DB.LargeBinary, nullable=False)
     admin_q       = DB.Column(DB.Boolean, nullable=False)
     x             = DB.Column(DB.Integer, nullable=True)
     y             = DB.Column(DB.Integer, nullable=True)
     items         = DB.relationship('Items', backref="player", lazy=True)
 
-    def __init__(self, user_name, password_hash, admin_q, x, y, items=None):
-        self.user_name     = user_name
+    def __init__(self, username, password_hash, admin_q, x, y, items=None):
+        self.username      = username
         self.password_hash = password_hash
         self.admin_q       = admin_q
         self.x             = x
@@ -53,7 +53,7 @@ class Users(DB.Model):
     def serialize(self):
         return {
             'id': self.id,
-            'user_name': self.user_name,
+            'username': self.username,
             'admin_q': self.admin_q,
             'x': self.x,
             'y': self.y,
@@ -63,8 +63,8 @@ class Users(DB.Model):
     def __repr__(self):
         output = {
             'id': self.id,
-            'user_name': self.user_name,
-            'auth_key': self.auth_key,
+            'password_hash': self.password_hash,
+            'username': self.username,
             'admin_q': self.admin_q,
             'x': self.x,
             'y': self.y,

--- a/DungeonAPI/player.py
+++ b/DungeonAPI/player.py
@@ -14,7 +14,7 @@ class Player:
         self.world         = world
         self.world_loc     = world_loc  # tuple of coordinates in world (x, y)
         self.max_weight    = 100
-        self.high_score    = highscore
+        self.highscore    = highscore
         # Inventory { key: Item.id, value: Item }
         self.items         = items if items else {}
 
@@ -56,3 +56,13 @@ class Player:
         else:
             print("You cannot move in that direction.")
             return False
+
+    def serialize(self):
+        return {
+            'id': self.id,
+            'username': self.username,
+            'world_loc': list(self.world_loc),
+            'weight': self.weight,
+            'highscore': self.highscore,
+            'items': self.items
+        }

--- a/DungeonAPI/player.py
+++ b/DungeonAPI/player.py
@@ -38,7 +38,7 @@ class Player:
 
         If there is no valid Room found, returns None.
         """
-        return world.rooms.get(self.world_loc, None)
+        return self.world.rooms.get(self.world_loc, None)
 
     def __generate_auth_key():
         digits = ['0', '1', '2', '3', '4', '5', '6',

--- a/DungeonAPI/player.py
+++ b/DungeonAPI/player.py
@@ -3,10 +3,10 @@ import uuid
 
 
 class Player:
-    def __init__(self, world, id, name, world_loc, password_hash, highscore=0, admin_q=False, items=None):
+    def __init__(self, world, id, name, world_loc, password_hash, auth_key=None, highscore=0, admin_q=False, items=None):
         self.id            = id
         self.username      = name
-        self.__auth_key    = Player.__generate_auth_key()
+        self.__auth_key    = auth_key if auth_key else Player.__generate_auth_key()
         self.password_hash = password_hash
         self.uuid          = uuid.uuid4
         self.admin_q       = admin_q
@@ -16,7 +16,7 @@ class Player:
         self.max_weight    = 100
         self.high_score    = highscore
         # Inventory { key: Item.id, value: Item }
-        self.items         = items if items is not None else {}
+        self.items         = items if items else {}
 
     @property
     def weight(self):
@@ -30,7 +30,7 @@ class Player:
         return self.__auth_key
 
     @property
-    def room(self):
+    def current_room(self):
         """
         `self.room`
 

--- a/DungeonAPI/room.py
+++ b/DungeonAPI/room.py
@@ -12,6 +12,15 @@ class Room:
         self.world_loc   = world_loc
         self.items       = items if items is not None else {}
 
+    def serialize(self):
+        return {
+            "id": self.id,
+            "name": self.name,
+            "description": self.description,
+            "world_loc": self.world_loc,
+            "items": self.items,
+        }
+
     def __repr__(self):
         return (
             f"{{\n"

--- a/DungeonAPI/world.py
+++ b/DungeonAPI/world.py
@@ -12,7 +12,7 @@ from .models import *
 
 class World:
 
-    def __init__(self, map_seed = None):
+    def __init__(self, map_seed=None):
         # rooms   { key: Room.world_loc,  value: Room }
         # players { key: Player.auth_key, value: Player }
 
@@ -78,7 +78,7 @@ class World:
 
     def create_world(self):
         map = Map(25, 150)
-        self.map_seed = map.generate_grid(map_seed = self.map_seed)
+        self.map_seed = map.generate_grid(map_seed=self.map_seed)
         self.rooms = map.generate_rooms(self)
 
     def save_to_db(self, DB):

--- a/DungeonAPI/world.py
+++ b/DungeonAPI/world.py
@@ -72,9 +72,21 @@ class World:
         self.players[player.auth_key] = player
         return {'message': 'logged in', 'key': player.auth_key}
 
-    def get_serialized_rooms(self):
-        return {f"{k[0]}-{k[1]}": v.serialize()
-                for k, v in self.rooms.items()}
+    def get_map_info(self):
+        """
+        Returns a dictionary the FE can use to build a map
+
+        Dict contains:
+            - coordinates where rooms exist
+            - coordinates where stores are
+        """
+        rooms, stores = [], []
+        for room_coord in self.rooms.keys():
+            # if isinstance(self.rooms[room_coord], Store):
+            #     stores.append(room_coord)
+            rooms.append(room_coord)
+
+        return {"rooms": rooms, "stores": stores}
 
     def create_world(self):
         map = Map(25, 150)

--- a/DungeonAPI/world.py
+++ b/DungeonAPI/world.py
@@ -109,7 +109,7 @@ class World:
 
         for p in self.players.values():
             new_user = Users(p.username, p.password_hash,
-                             p.admin_q, p.world_loc[0], p.world_loc[1])
+                             p.admin_q, p.world_loc[0], p.world_loc[1], highscore=p.highscore)
             DB.session.add(new_user)
 
             for i in p.items:


### PR DESCRIPTION
# Changelog

### Remaining HTTP Routes:
- "/" - hello world
- "/api/check" - create world with rooms
- all blueprint routes are still the same

### Socketio Routes:

#### "connect"
- simple connect function

####- "disconnect"
- simple disconnect function
- Will eventually save the player information on disconnect

#### "test"
- **Required:** JSON(any)
- will return any data sent to server

#### "registration"
- **Required:** JSON (username, password1, password2)
- Creates a new player in database, loads player into world
- returns socketid on sucessful request (does not need to be saved on FE)

#### "login"
- **Required:** JSON (username, password)
- Verifies user from database, loads player into world
- returns socketid on sucessful request (does not need to be saved on FE)

#### "debug", "debug/save", "debug/load", "debug/reset"
- Made as socketio admin routes
- Entry not permitted until we create a user with `admin_q == True`

#### "init"
- **Required:** NO BODY
- returns with all rooms in the world, and the logged in user

#### "move"
- **Required:** JSON(direction)
- Example of FE request: `socket.emit("move", {direction: "n"})`
- returns new room, and player info

### socket.on:
Errors have a message name that matches the request.
#### Example:
If the server recieves
```("login", {})```
The error response will be  
```("loginError", "Invalid Username")```

If the server recieves 
```("login", {username: "6k6", password:"fdfhgg"})```
The success response will be 
```("login", {key: socketio_key})```