### PR TITLE
Feature/room info

### DIFF
--- a/DungeonAPI/item.py
+++ b/DungeonAPI/item.py
@@ -28,6 +28,9 @@ class Item:
             'score': self.score,
         }
 
+    def create_items(items):
+        return {i.id: db_to_class(i) for i in items}
+
 
 class Trash(Item):
     """Item with low score, low-ish weight. Try not to get too much."""

--- a/DungeonAPI/player.py
+++ b/DungeonAPI/player.py
@@ -1,6 +1,6 @@
 import random
 import uuid
-from .item import db_to_class
+from .item import Item
 
 
 class Player:
@@ -17,7 +17,7 @@ class Player:
         self.max_weight    = 100
         self.highscore     = highscore
         # Inventory { key: Item.id, value: Item }
-        self.items         = Player.create_items(items) if items else {}
+        self.items         = Item.create_items(items) if items else {}
 
     @property
     def weight(self):
@@ -48,9 +48,6 @@ class Player:
         for i in range(40):
             auth_key_list.append(random.choice(digits))
         return "".join(auth_key_list)
-
-    def create_items(items):
-        return {i.id: db_to_class(i) for i in items}
 
     def travel(self, direction, show_rooms=False):
         next_room = self.current_room.get_room_in_direction(direction)

--- a/DungeonAPI/player.py
+++ b/DungeonAPI/player.py
@@ -58,6 +58,19 @@ class Player:
             print("You cannot move in that direction.")
             return False
 
+    def drop_item(self, item_id):
+        if item_id not in self.items:
+            return False
+        item = self.items.pop(item_id)
+        return self.current_room.add_item(item)
+
+    def take_item(self, item_id):
+        item = self.current_room.remove_item(item_id)
+        if not item or not item.id:
+            return False
+        self.items[item.id] = item
+        return True
+
     def serialize(self):
         return {
             'id': self.id,

--- a/DungeonAPI/room.py
+++ b/DungeonAPI/room.py
@@ -1,6 +1,4 @@
-# Implement a class to hold room information. This should have name and
-# description attributes.
-
+from .item import Item
 
 class Room:
 
@@ -10,7 +8,7 @@ class Room:
         self.name        = name
         self.description = description
         self.world_loc   = world_loc
-        self.items       = items if items is not None else {}
+        self.items       = Item.create_items(items) if items is not None else {}
 
     def serialize(self):
         return {
@@ -18,7 +16,7 @@ class Room:
             "name": self.name,
             "description": self.description,
             "world_loc": self.world_loc,
-            "items": self.items,
+            "items": [item.serialize() for item in self.items.values()],
             "direction": self.directions
         }
 

--- a/DungeonAPI/room.py
+++ b/DungeonAPI/room.py
@@ -19,6 +19,7 @@ class Room:
             "description": self.description,
             "world_loc": self.world_loc,
             "items": self.items,
+            "direction": self.directions
         }
 
     def __repr__(self):
@@ -31,6 +32,14 @@ class Room:
             f"\t\titems: {self.items},\n"
             f"\t}}\n"
         )
+
+    @property
+    def directions(self):
+        dir_list = []
+        for d in "nesw":
+            if self.get_room_in_direction(d) is not None:
+                dir_list.append(d)
+        return dir_list
 
     def get_room_in_direction(self, direction):
         if direction == 'n':

--- a/DungeonAPI/room.py
+++ b/DungeonAPI/room.py
@@ -51,6 +51,17 @@ class Room:
         else:
             return None
 
+    def add_item(self, item):
+        if not item or not item.id:
+            return False
+        self.items[item.id] = item
+        return True
+
+    def remove_item(self, item_id):
+        if item_id not in self.items:
+            return None
+        return self.items.pop(item_id)
+
 class Tunnel(Room):
 
     def __init__(self, world, world_loc, id=0, items=None):


### PR DESCRIPTION
# Changelog
- Adds the ability to take and drop items
- Sends `roomupdate` to all players in a room when any player 
    - inits in the room
    - moves into the room
    - takes an item from the room
    - drops an item into the room
    - Does **not** send a message when a player leaves a room (this could be implemented, though I'm not sure if we want this. Our chat could quickly clog with "player entered, player left, player entered, player left")

#### Item class
- Adds class method `Item.create_items(items)`
    - Creates an item dictionary from an item list loaded from the DB

#### Player class
- Uses `Item.create_items(items)` in `__init__`
- Adds `take_item` method
- Adds `drop_item` method

#### Room class
- Uses `Item.create_items(items)` in `__init__`
- Adds `add_item` method
- Adds `remove_item` method

## How to test

### Socket info

**Message:** `login`
**data:** `{"username":"6k6","password":"fdfhgg"}`

**Message:** `registration`
**Data:** `{"username":"Dank","password1":"asdfasdf","password2":"asdfasdf"}`

**Message**: `init`
**data:** NONE

**Message:** "move"
**data:** "n"

**Message:** "drop"
**data:** 1

**Message:** "take"
**data:** 1

### Steps
- Use https://socketiotesting.netlify.app/
    - Use two tabs to see interaction between players
- login as user "6k6"
- register in second tab/window as a new user
- init both windows
- as user 6k6, drop an item
    - This message should be displayed in both window consoles
- As either user, take the item previously dropped
    - This message should be displayed in both window consoles