### PR TITLE
POSTGRES FIX - worlds.save_to_db()

### DIFF
--- a/DungeonAPI/world.py
+++ b/DungeonAPI/world.py
@@ -123,23 +123,23 @@ class World:
             new_room = Rooms(r.name, r.description,
                              r.world_loc[0], r.world_loc[1])
             DB.session.add(new_room)
+            DB.session.commit()
 
             for i in r.items.values():
-                new_item = Items(i.name, i.weight, i.score, room_id=r.id)
+                new_item = Items(i.name, i.weight, i.score, room_id=new_room.id)
                 items.append(new_item)
 
-        DB.session.commit()
 
         for p in self.players.values():
             new_user = Users(p.username, p.password_hash,
                              p.admin_q, p.world_loc[0], p.world_loc[1], highscore=p.highscore)
             DB.session.add(new_user)
+            DB.session.commit()
 
             for i in p.items.values():
-                new_item = Items(i.name, i.weight, i.score, player_id=p.id)
+                new_item = Items(i.name, i.weight, i.score, player_id=new_user.id)
                 items.append(new_item)
 
-        DB.session.commit()
 
         DB.session.bulk_save_objects(items)
         DB.session.commit()


### PR DESCRIPTION
## Issue
Previously, when saving to the database, the items would not have the correct `room.id` when saving. With sqlite, no error is thrown, but with PostgreSQL, this error appears:
```
sqlalchemy.exc.IntegrityError: (psycopg2.errors.ForeignKeyViolation) insert or update on table "items" violates foreign key constraint "items_room_id_fkey"
DETAIL:  Key (room_id)=(180) is not present in table "rooms".
```
## Fix
commit each room and player immediately after adding, and grab the id from the database model for the items. This way, every foreign key given to an item will truly match a room or player in the db.