### PR TITLE
Player save and load; Server initialization

### DIFF
--- a/DungeonAPI/app.py
+++ b/DungeonAPI/app.py
@@ -89,17 +89,14 @@ def create_app():
     DB.init_app(app)
 
     with app.app_context():
-        # Creates world with one player and 3 items in our DB
-        world.create_world()  # TODO: Remove when done testing.
-        world.save_to_db(DB)
-        quth = world.add_player("6k6", "fdfhgg", "fdfhgg")["key"]
-        player_u = world.get_player_by_auth(quth)
-        new_i1 = Items("Hammer", 0, 0, player_id=player_u.id)
-        new_i2 = Items("Trash", 10, 5, player_id=player_u.id)
-        new_i3 = Items("Gem", 25, 50, player_id=player_u.id)
-        DB.session.bulk_save_objects([new_i1, new_i2, new_i3])
-        DB.session.commit()
+        # Loads our world
         world.load_from_db(DB)
+
+        if len(world.rooms) == 0:
+            # If the world is empty, creates one
+            world.create_world()  # TODO: Remove when done testing.
+            world.save_to_db(DB)
+
 
     @app.after_request
     def after_request(response):
@@ -135,6 +132,9 @@ def create_app():
     @socketio.on("disconnect")
     def disconnect():
         print_socket_info(request.sid, "Left the server.")
+        player = world.get_player_by_auth(request.sid)
+        if player is not None:
+            world.save_player_to_db(player)
 
     @socketio.on("test")
     def test(data):

--- a/DungeonAPI/app.py
+++ b/DungeonAPI/app.py
@@ -13,7 +13,7 @@ from .player import Player
 from .world import World
 from .blueprints import items_blueprint, users_blueprint, rooms_blueprint, worlds_blueprint
 
-from .models import DB, Users, Items, Worlds
+from .models import DB, Users, Items, Worlds, Rooms
 
 
 def create_app():
@@ -90,13 +90,26 @@ def create_app():
     DB.init_app(app)
 
     with app.app_context():
-        # Loads our world
+        # Create Tables if they don't already exist
+        Worlds.__table__.create(DB.engine, checkfirst=True)
+        Rooms.__table__.create(DB.engine, checkfirst=True)
+        Items.__table__.create(DB.engine, checkfirst=True)
+        Users.__table__.create(DB.engine, checkfirst=True)
+        # Loads our world if it exists
         world.load_from_db(DB)
-
+        
         if len(world.rooms) == 0:
             # If the world is empty, creates one
-            world.create_world()  # TODO: Remove when done testing.
+            world.create_world()
             world.save_to_db(DB)
+        if len(Users.query.all()) == 0:
+            # If we have no users, start with our admin user
+            username = config("ADMIN_USERNAME")
+            password = config("ADMIN_PASSWORD")
+            quth = world.add_player(username, password, password)
+            if 'key' in quth:
+                player = world.get_player_by_auth(quth['key'])
+                world.save_player_to_db(player)
 
 
     @app.after_request

--- a/DungeonAPI/world.py
+++ b/DungeonAPI/world.py
@@ -13,7 +13,7 @@ from .models import *
 
 class World:
 
-    def __init__(self, map_seed=None):
+    def __init__(self, map_seed=16358):
         # rooms   { key: Room.world_loc,  value: Room }
         # players { key: Player.auth_key, value: Player }
 
@@ -23,7 +23,6 @@ class World:
         self.highscores    = [None, None, None]
         self.loaded        = False
         self.map_seed      = map_seed
-        self.create_world()
 
     def add_player(self, username, password1, password2, socketid=None):
         """
@@ -224,13 +223,16 @@ class World:
     def load_from_db(self, DB):
         """
         Loads all Rooms and any associated items from the database
-        into the game.
+        into the game, if they exist.
 
         This function does NOT load any players. Use `add_player()`
         or `load_player_from_db()` to load players into the game.
         """
-        self.password_salt = Worlds.query.all()[0].password_salt
-        self.map_seed = Worlds.query.all()[0].map_seed
+        db_worlds = Worlds.query.all()
+        if db_worlds is None or len(db_worlds) == 0:
+            return
+        self.password_salt = db_worlds[0].password_salt
+        self.map_seed = db_worlds[0].map_seed
 
         self.rooms = {}
         self.players = {}


### PR DESCRIPTION
# Changelog
- When a player disconnects from the server, their world location and items will be auto-saved
- When the server starts, it will:
    - Create all tables if they don't exist
    - try loading world data from the DB
    - If the data doesn't exist in the DB, it creates a new world and saves
    - If there are no users, creates one user as an admin user
        - **You MUST have two new env variables:**
            - `ADMIN_USERNAME`
            - `ADMIN_PASSWORD`
- When the world saves, it only saves Worlds/Rooms/Items
- When the world loads, it only loads its rooms and associated items

# How to Test
## Tool
Use https://socketiotesting.netlify.app/

## Steps
- Delete your database (erase the sqlite file, or drop all psql tables)
- Start the server
- login with your admin username/password
    - admin user should exist, rooms and items should also exist
- init, and move through the world
- take items into your inventory
- refresh the FE client
- re-login and init
    - The items you grabbed should still be in your inventory
    - You should be in the room where you last were
- Restart the server
- Re-login and init
    - Everything should still be the same (rooms, items, location, etc)

## To do ?
Currently, if the server stops before any player disconnects, their items are not saved. 

This would require the `take_item` and `drop_item` functions to update item info in the database