### PR TITLE
Changes DB order to keep many-to-one relation

### DIFF
--- a/DungeonAPI/app.py
+++ b/DungeonAPI/app.py
@@ -93,8 +93,8 @@ def create_app():
         # Create Tables if they don't already exist
         Worlds.__table__.create(DB.engine, checkfirst=True)
         Rooms.__table__.create(DB.engine, checkfirst=True)
-        Items.__table__.create(DB.engine, checkfirst=True)
         Users.__table__.create(DB.engine, checkfirst=True)
+        Items.__table__.create(DB.engine, checkfirst=True)
         # Loads our world if it exists
         world.load_from_db(DB)
         

--- a/DungeonAPI/world.py
+++ b/DungeonAPI/world.py
@@ -191,13 +191,13 @@ class World:
 
         User data is preserved.
         """
+        Items.__table__.drop(DB.engine, checkfirst=True)
         Worlds.__table__.drop(DB.engine, checkfirst=True)
         Rooms.__table__.drop(DB.engine, checkfirst=True)
-        Items.__table__.drop(DB.engine, checkfirst=True)
         Worlds.__table__.create(DB.engine)
         Rooms.__table__.create(DB.engine)
-        Items.__table__.create(DB.engine)
         Users.__table__.create(DB.engine, checkfirst=True)
+        Items.__table__.create(DB.engine)
 
         new_world = Worlds(self.password_salt, self.map_seed)
         DB.session.add(new_world)

--- a/DungeonAPI/world.py
+++ b/DungeonAPI/world.py
@@ -230,6 +230,7 @@ class World:
         """
         db_worlds = Worlds.query.all()
         if db_worlds is None or len(db_worlds) == 0:
+            DB.session.commit()
             return
         self.password_salt = db_worlds[0].password_salt
         self.map_seed = db_worlds[0].map_seed
@@ -246,3 +247,4 @@ class World:
             self.rooms[room.world_loc] = room
 
         self.loaded = True
+        DB.session.commit()


### PR DESCRIPTION
# Issues
- Items table has a many-to-one relation with Rooms and Users. This means that Rooms and Users must exist before Items can, and that Items must drop before Rooms and Users can.
- PostgreSQL does not let you drop a table if the table is considered 'open'. This means, anytime you interact with the DB, you must close it via `DB.session.commit()` or something similar.

This PR fixes the above issues.