### PR TITLE
Improve highscore sending

### DIFF
--- a/DungeonAPI/app.py
+++ b/DungeonAPI/app.py
@@ -268,8 +268,11 @@ def create_app():
     def init(player, *_, **__):
         print_socket_info(request.sid)
 
-        # Send map information
+        # Send map and highscore information
         response = player.world.get_map_info(),
+        highscoreupdate = player.world.confirm_highscores(
+            player, single_socket=True)
+        emit("highscoreupdate", highscoreupdate)
         emit('mapinfo', response)
         emit('playerupdate', player.serialize())
         # Send current room information

--- a/DungeonAPI/world.py
+++ b/DungeonAPI/world.py
@@ -126,7 +126,7 @@ class World:
         DB.session.commit()  # Save DB changes
         self.players.pop(player.auth_key)
 
-    def confirm_highscores(self, player):
+    def confirm_highscores(self, player, single_socket=False):
         """
         Checks the player's highscore with the top three.
 
@@ -135,11 +135,19 @@ class World:
 
         emits "highscoreupdate"
         """
-        sendScores = False
-        if player in self.highscores:
-            # Even if the player doesn't move a place,
-            # their score change still needs to be sent
-            sendScores = True
+        send_scores = False
+
+        in_highscores = False
+        for p in self.highscores:
+            # Check whether our current player is
+            # already in our highscore roster
+            if isinstance(p, Player) and p.id == player.id:
+                in_highscores = True
+
+        if in_highscores:
+            # If the player is in the highscores array
+            # loop through the array to update player order
+            send_scores = True
             for i in range(2, 0, -1):
                 if self.highscores[i - 1] is None or (self.highscores[i] and self.highscores[i].highscore > self.highscores[i - 1].highscore):
                     # If the compare value is None, or
@@ -148,22 +156,30 @@ class World:
                     temp = self.highscores[i]
                     self.highscores[i] = self.highscores[i - 1]
                     self.highscores[i - 1] = temp
+
         else:
+            # If the player is not in the highscores,
+            # Check if their highscore places them in the top three
             for i in range(2):
                 if self.highscores[i] is None or player.highscore > self.highscores[i].highscore:
                     # If you find a highscore lower than the player, or
                     # the compared spot is None, stick the player in there
-                    sendScores = True
+                    send_scores = True
                     temp = player
                     player = self.highscores[i]
                     self.highscores[i] = temp
-        if sendScores:
-            send_highscores = [None, None, None]
-            for i in range(len(self.highscores)):
-                p = self.highscores[i]
-                if isinstance(p, Player):
-                    send_highscores[i] = f"{p.username} {p.highscore}"
-            emit("highscoreupdate", send_highscores, broadcast=True)
+
+        if send_scores or single_socket:
+            # If our highscore values changed,
+            # send the new highscore info to everyone
+            send_highscores = [
+                f"{p.username} {p.highscore}" for p in self.highscores if isinstance(p, Player)]
+            if single_socket:
+                # Single socket → someone just loaded into the world.
+                # return the highscores so they will be sent only to the player
+                return send_highscores
+            else:
+                emit("highscoreupdate", send_highscores, broadcast=True)
 
     def get_map_info(self):
         """


### PR DESCRIPTION
# Issue
- When a player first loads into the world, they can't see any highscores
- If a player leaves, re-joins, and then reaches the highscores again, their name will appear twice
    - This is because the world is checking if the player classes are the same, not if a concrete value (like the player id) is the same

# Fix
- On `'init'`, the highscores are sent only to the player
- World now checks the player's id to confirm whether they're in the highscores 


# How to Test

## Tool
https://socketiotesting.netlify.app/

## Steps
- Login/register as a user
- init into the world. You should see:
    - mapinfo
    - playerupdate
    - roomupdate
    - highscoreupdate
- Refresh the Front End (not the server!)
- login again
- init again. You should see:
    - The same four socket responses as above
    - The higscoreupdate response should have your username listed only once